### PR TITLE
Correct structure for unit tests namespace

### DIFF
--- a/PromotionEngineConsoleAppTest/UnitTestPromotionEngineViewModel.cs
+++ b/PromotionEngineConsoleAppTest/UnitTestPromotionEngineViewModel.cs
@@ -2,8 +2,10 @@ using NUnit.Framework;
 using System;
 using Promotion.Engine.Library;
 using System.Collections.Generic;
+using Promotion.Engine.ConsoleApp;
 
-namespace Promotion.Engine.ConsoleApp.UnitTests;
+namespace Promotion.Engine.UnitTests.ConsoleApp;
+[TestFixture]
 public class UnitTestPromotionEngineViewModel
 {
     [SetUp]

--- a/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
+++ b/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
@@ -3,8 +3,10 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using StackExchange.Profiling;
+using Promotion.Engine.Library;
 
-namespace Promotion.Engine.Library.Test;
+namespace Promotion.Engine.UnitTests.Library;
+[TestFixture]
 public class UnitTestPromotionEngineLibrary
 {
     [SetUp]


### PR DESCRIPTION
Description: namespace structure was incorrect and did not establish a common namespace for all unit tests in project Promotion Engine as the following will Promotion.Engine.UnitTests.xx