### PR TITLE
Feature algo overlapping rules

### DIFF
--- a/PromotionEngineLibrary/PromotionRule.cs
+++ b/PromotionEngineLibrary/PromotionRule.cs
@@ -8,8 +8,8 @@ public class PromotionRule
     public string Item_i {get;}
     public string? Item_j {get;}
     public IEnumerable<string?> Items {get;}
-    public int Idx_i {get;}
-    public int Idx_j {get;}
+    public int IdxProduct_i {get;}
+    public int IdxProduct_j {get;}
     public string? PrintRule {get;}
     public Func<IEnumerable<int>?, int, int, int> OccurencesDelegate {get; set;}
 
@@ -18,8 +18,8 @@ public class PromotionRule
         Item_i = item_i;
         Item_j = item_j;
         Items = new List<string?>{item_i, item_j};
-        Idx_i = idx_i;
-        Idx_j = idx_j;
+        IdxProduct_i = idx_i;
+        IdxProduct_j = idx_j;
         Price = price;
         Saving = saving;
         if (!String.IsNullOrEmpty(Item_j))
@@ -29,7 +29,7 @@ public class PromotionRule
 
     public int PromotionOccurences(IEnumerable<int>? counts)
     {
-        var occurences = OccurencesDelegate(counts, Idx_i, Idx_j);
+        var occurences = OccurencesDelegate(counts, IdxProduct_i, IdxProduct_j);
         return occurences;
     }
 

--- a/PromotionEngineLibrary/PromotionRule.cs
+++ b/PromotionEngineLibrary/PromotionRule.cs
@@ -7,6 +7,7 @@ public class PromotionRule
     public int Saving {get;}
     public string Item_i {get;}
     public string? Item_j {get;}
+    public IEnumerable<string?> Items {get;}
     public int Idx_i {get;}
     public int Idx_j {get;}
     public string? PrintRule {get;}
@@ -16,6 +17,7 @@ public class PromotionRule
     {
         Item_i = item_i;
         Item_j = item_j;
+        Items = new List<string?>{item_i, item_j};
         Idx_i = idx_i;
         Idx_j = idx_j;
         Price = price;

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -1,0 +1,15 @@
+
+namespace Promotion.Engine.Library;
+public static class RuleOverlapAlgo
+{
+    public static IEnumerable<int> OptimizeRulesApplied(this IEnumerable<int> countsSKU)
+    {
+        return new List<int>();
+    }
+
+    public static int OverlappingPromotionRules(this IEnumerable<int> rulesAppliedCount)
+    {
+        return 1;
+    }
+    
+}

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -19,9 +19,6 @@ public static class RuleOverlapAlgo
         bool noOverlapWithEarlierRules;
         foreach (var rule in promotionRules)
         {
-            // Todo: implement logic that prevents overlap and optimizes the total savings
-            // Simple check would be that if rule has overlap with earlier added rule, then skip.
-            
             noOverlapWithEarlierRules = promotionRulesApplied.OverLappingRulesIndices(rule).Count() == 0;
             if (noOverlapWithEarlierRules)
             {
@@ -35,26 +32,15 @@ public static class RuleOverlapAlgo
 
     public static int OverlappingPromotionRules(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules)
     {
-        // Either do a check on PromotionRule class members Item_i and Item_j which is similar to checking instead if any of idx_i or idx_j matches
-        // Only check overlaps for rules with an applied count > 0
         int overlappingPromotionRulesCount = 0;
         IEnumerable<int> overlappingRulesIndices;
         var appliedPromotionRulesQuery = promotionRules.Where(x => rulesAppliedCount.ToList<int>().ElementAt(x.Idx_i) > 0);
-
-        // Debug
-        var isPromotionRulesDimSame = promotionRules.Count() == appliedPromotionRulesQuery.Count();
 
         foreach (var rule in appliedPromotionRulesQuery)
         {
             if (appliedPromotionRulesQuery.Where(x => x != rule).Count() > 0)
             {
-                // var overlappingRulesIndicesTest = promotionRules.Where(
-                //     x => x.Item_i == rule.Item_i & rulesAppliedCount.ToList<int>().ElementAt(x.Idx_i) > 0 
-                //     & promotionRules.ToList<PromotionRule>().IndexOf(rule) != promotionRules.ToList<PromotionRule>().IndexOf(x)).Select(
-                //         x => promotionRules.ToList<PromotionRule>().IndexOf(x));
-
                 overlappingRulesIndices = appliedPromotionRulesQuery.OverLappingRulesIndices(rule);
-                // var isOverlappingRulesIndicesEqual = overlappingRulesIndices.SequenceEqual(overlappingRulesIndicesTest);
                 overlappingPromotionRulesCount += overlappingRulesIndices.Count();
             }
         }

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -16,11 +16,14 @@ public static class RuleOverlapAlgo
     {
         List<int> promotionRulesAppliedCount = new List<int>(new int[promotionRules.Count()]);
         List<PromotionRule> promotionRulesApplied = new List<PromotionRule>(promotionRules.Count());
+        bool noOverlapWithEarlierRules;
         foreach (var rule in promotionRules)
         {
             // Todo: implement logic that prevents overlap and optimizes the total savings
             // Simple check would be that if rule has overlap with earlier added rule, then skip.
-            if (promotionRulesApplied.OverLappingRulesIndices(rule).Count() == 0)
+            
+            noOverlapWithEarlierRules = promotionRulesApplied.OverLappingRulesIndices(rule).Count() == 0;
+            if (noOverlapWithEarlierRules)
             {
                 promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
                 if (rule.PromotionOccurences(countsSKU) > 0)
@@ -57,6 +60,11 @@ public static class RuleOverlapAlgo
         }
         // Divide by 2 since same overlap gets counted twice
         return overlappingPromotionRulesCount/2;
+    }
+
+    public static int OverlappingSKUConsumptionInRules()
+    {
+        throw new NotImplementedException("Please create a test first.");
     }
 
     private static IEnumerable<int> OverLappingRulesIndices(this IEnumerable<PromotionRule> appliedPromotionRulesQuery, PromotionRule rule)

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -53,4 +53,14 @@ public static class RuleOverlapAlgo
         // Divide by 2 since same overlap gets counted twice
         return overlappingPromotionRulesCount/2;
     }
+
+    public static void MaxSavings()
+    {
+        throw new NotImplementedException("Please create a test first.");
+    }
+
+    public static void OptimizeRulesAppliedAndMaxSavings()
+    {
+        throw new NotImplementedException("Please create a test first.");
+    }
 }

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -25,6 +25,8 @@ public static class RuleOverlapAlgo
                 promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
                 if (rule.PromotionOccurences(countsSKU) > 0)
                     promotionRulesApplied.Add(rule);
+
+            // Todo: Subtract consumed SKU from countsSKU using method OverlappingSKUConsumptionInRules()
             }
         }
         return promotionRulesAppliedCount;
@@ -48,7 +50,7 @@ public static class RuleOverlapAlgo
         return overlappingPromotionRulesCount/2;
     }
 
-    public static int OverlappingSKUConsumptionInRules(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
+    public static IEnumerable<int> OverlappingSKUConsumptionInRules(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
     {
         // Todo: for each applied promotion rule use number of times it was applied in rulesAppliedCount together 
         // with Items member of a promotion to compute sum of SKU consumption that should not be larger than actual countsSKU
@@ -78,7 +80,12 @@ public static class RuleOverlapAlgo
         skuConsumed = String.Join(",", skuConsumed.Split(",").Where(x => x != ""));
         var stockKeepingUnits = new List<string>(skuConsumed.Split(","));
         var appliedRulesSKUcounts = stockKeepingUnits.CountSKU();
+        return appliedRulesSKUcounts;
+    }
 
+    public static int OverlappingSKUConsumptionInRulesSum(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
+    {
+        var appliedRulesSKUcounts = rulesAppliedCount.OverlappingSKUConsumptionInRules(promotionRules, countsSKU);
         var diff = appliedRulesSKUcounts.Select(x => x - countsSKU.ToList().ElementAt(appliedRulesSKUcounts.ToList<int>().IndexOf(x)));
         return diff.Sum();
     }

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -1,4 +1,3 @@
-
 namespace Promotion.Engine.Library;
 public static class RuleOverlapAlgo
 {
@@ -15,11 +14,10 @@ public static class RuleOverlapAlgo
     public static IEnumerable<int> OptimizeRulesApplied(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
     {
         List<int> promotionRulesAppliedCount = new List<int>(new int[promotionRules.Count()]);
-        List<PromotionRule> promotionRulesApplied = new List<PromotionRule>(promotionRules.Count());
         List<int> countsSKUState = new List<int>(new int[countsSKU.Count()]);
         UpdateCounts(ref countsSKUState, (List<int>)countsSKU);
 
-        IEnumerable<int> countsSKUSubtractedConsumedSKUQuery;
+        IEnumerable<int> countsSKUSubtractedConsumedSKU;
         var idxRule = 0;
         
         foreach (var rule in promotionRules)
@@ -27,13 +25,13 @@ public static class RuleOverlapAlgo
             promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKUState);
 
             // Reset list with 0s
-            var counstByAppliedRule = new List<int>(new int[promotionRules.Count()]);
-            counstByAppliedRule[idxRule] = rule.PromotionOccurences(countsSKUState);
-            var countsConsumed = counstByAppliedRule.OverlappingSKUConsumptionInRules(promotionRules, countsSKUState);
+            var countsOnlyByAppliedRule = new List<int>(new int[promotionRules.Count()]);
+            countsOnlyByAppliedRule[idxRule] = rule.PromotionOccurences(countsSKUState);
+            var countsConsumed = countsOnlyByAppliedRule.SKUConsumptionInRules(promotionRules, countsSKUState);
 
-            countsSKUSubtractedConsumedSKUQuery = SubtractConsumedCounts(countsSKUState, countsConsumed);
+            countsSKUSubtractedConsumedSKU = SubtractConsumedCounts(countsSKUState, countsConsumed);
 
-            UpdateCounts(ref countsSKUState, countsSKUSubtractedConsumedSKUQuery);
+            UpdateCounts(ref countsSKUState, countsSKUSubtractedConsumedSKU);
             idxRule++;
         }
         return promotionRulesAppliedCount;
@@ -75,7 +73,7 @@ public static class RuleOverlapAlgo
         return overlappingPromotionRulesCount/2;
     }
 
-    public static IEnumerable<int> OverlappingSKUConsumptionInRules(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
+    public static IEnumerable<int> SKUConsumptionInRules(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
     {
         // Todo: for each applied promotion rule use number of times it was applied in rulesAppliedCount together 
         // with Items member of a promotion to compute sum of SKU consumption that should not be larger than actual countsSKU
@@ -109,9 +107,9 @@ public static class RuleOverlapAlgo
         return appliedRulesSKUcounts;
     }
 
-    public static int OverlappingSKUConsumptionInRulesSum(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
+    public static int SKUConsumptionInRulesSum(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
     {
-        var appliedRulesSKUcounts = rulesAppliedCount.OverlappingSKUConsumptionInRules(promotionRules, countsSKU);
+        var appliedRulesSKUcounts = rulesAppliedCount.SKUConsumptionInRules(promotionRules, countsSKU);
         var diff = appliedRulesSKUcounts.Select(x => x - countsSKU.ToList().ElementAt(appliedRulesSKUcounts.ToList<int>().IndexOf(x)));
         return diff.Sum();
     }

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -24,28 +24,7 @@ public static class RuleOverlapAlgo
         
         foreach (var rule in promotionRules)
         {
-            // noOverlapWithEarlierRules = promotionRulesApplied.OverLappingRulesIndices(rule).Count() == 0;
-            // if (noOverlapWithEarlierRules)
-            // {
-            //     promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKUState);
-            //     if (rule.PromotionOccurences(countsSKUState) > 0)
-            //         promotionRulesApplied.Add(rule);
-            // }
-
-            // Todo: Subtract consumed SKU from countsSKU using method OverlappingSKUConsumptionInRules()
             promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKUState);
-
-            // // Debug
-            // if (rule.IdxProduct_j == 2)
-            //     Console.WriteLine("2. rule");
-
-            // var countsConsumed = promotionRulesAppliedCount
-            //     .Where(x => promotionRulesAppliedCount.ToList().IndexOf(x) == promotionRules.ToList<PromotionRule>()
-            //     .IndexOf(rule)).OverlappingSKUConsumptionInRules(promotionRules, countsSKUState);
-
-            // Todo: promotionRulesAppliedCount.ToList<int>().IndexOf(x) does only return a value if x is a unique of course
-            // var counstByAppliedRule = promotionRulesAppliedCount
-            //     .Where(x => promotionRulesAppliedCount.ToList<int>().IndexOf(x) == promotionRules.ToList<PromotionRule>().IndexOf(rule));
 
             // Reset list with 0s
             var counstByAppliedRule = new List<int>(new int[promotionRules.Count()]);
@@ -109,8 +88,6 @@ public static class RuleOverlapAlgo
         {
             if (ruleAppliedCount > 0)
             {
-                // ruleAppliedCount does not allow for inverse determination of indices since values are not uniques
-                // idxRule = rulesAppliedCount.ToList<int>().IndexOf(ruleAppliedCount);
                 rule = promotionRules.ToList<PromotionRule>().ElementAt(idxRule);
 
                 ruleItems = String.Join(",", rule.Items.Where(x => x != null));

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -2,14 +2,39 @@
 namespace Promotion.Engine.Library;
 public static class RuleOverlapAlgo
 {
-    public static IEnumerable<int> OptimizeRulesApplied(this IEnumerable<int> countsSKU)
+    public static IEnumerable<int> OptimizeRulesApplied(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
     {
-        return new List<int>();
+        // Todo: count every time a rule is applied. Find index of promotion rule in list PromotionRules and add 1 foreach time it is applied
+        // How to use something like PromotionRules.IndexOf(promotionRule) would probably be the right way since,
+        // List<PromotionRule>? PromotionRules
+
+        List<int> promotionRulesAppliedCount = new List<int>(new int[promotionRules.Count()]);
+        foreach (var rule in promotionRules)
+        {
+            promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
+        }
+
+        return promotionRulesAppliedCount;
     }
 
-    public static int OverlappingPromotionRules(this IEnumerable<int> rulesAppliedCount)
+    public static int OverlappingPromotionRules(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules)
     {
-        return 1;
+        // Either do a check on PromotionRule class members Item_i and Item_j which is similar to checking instead if any of idx_i or idx_j matches
+        // Only check overlaps for rules with an applied count > 0
+        int overlappingPromotionRulesCount = 0;
+        IEnumerable<int> overlappingRulesIndices;
+        foreach (var rule in promotionRules)
+        {
+            if (promotionRules.Where(x => x.Item_i == rule.Item_i).Count() > 0)
+            {
+                overlappingRulesIndices = promotionRules.Where(
+                    x => x.Item_i == rule.Item_i & rulesAppliedCount.ToList<int>().ElementAt(x.Idx_i) > 0 
+                    & promotionRules.ToList<PromotionRule>().IndexOf(rule) != promotionRules.ToList<PromotionRule>().IndexOf(x)).Select(
+                        x => promotionRules.ToList<PromotionRule>().IndexOf(x));
+                overlappingPromotionRulesCount += overlappingRulesIndices.Count();
+            }
+        }
+        // Divide by 2 since same overlap gets counted twice
+        return overlappingPromotionRulesCount/2;
     }
-    
 }

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -29,19 +29,43 @@ public static class RuleOverlapAlgo
         // Only check overlaps for rules with an applied count > 0
         int overlappingPromotionRulesCount = 0;
         IEnumerable<int> overlappingRulesIndices;
-        foreach (var rule in promotionRules)
+        var appliedPromotionRulesQuery = promotionRules.Where(x => rulesAppliedCount.ToList<int>().ElementAt(x.Idx_i) > 0);
+
+        // Debug
+        var isPromotionRulesDimSame = promotionRules.Count() == appliedPromotionRulesQuery.Count();
+
+        foreach (var rule in appliedPromotionRulesQuery)
         {
-            if (promotionRules.Where(x => x.Item_i == rule.Item_i).Count() > 0)
+            if (appliedPromotionRulesQuery.Where(x => x != rule).Count() > 0)
             {
-                overlappingRulesIndices = promotionRules.Where(
-                    x => x.Item_i == rule.Item_i & rulesAppliedCount.ToList<int>().ElementAt(x.Idx_i) > 0 
-                    & promotionRules.ToList<PromotionRule>().IndexOf(rule) != promotionRules.ToList<PromotionRule>().IndexOf(x)).Select(
-                        x => promotionRules.ToList<PromotionRule>().IndexOf(x));
+                // var overlappingRulesIndicesTest = promotionRules.Where(
+                //     x => x.Item_i == rule.Item_i & rulesAppliedCount.ToList<int>().ElementAt(x.Idx_i) > 0 
+                //     & promotionRules.ToList<PromotionRule>().IndexOf(rule) != promotionRules.ToList<PromotionRule>().IndexOf(x)).Select(
+                //         x => promotionRules.ToList<PromotionRule>().IndexOf(x));
+
+                overlappingRulesIndices = appliedPromotionRulesQuery.OverLappingRulesIndices(rule);
+                // var isOverlappingRulesIndicesEqual = overlappingRulesIndices.SequenceEqual(overlappingRulesIndicesTest);
                 overlappingPromotionRulesCount += overlappingRulesIndices.Count();
             }
         }
         // Divide by 2 since same overlap gets counted twice
         return overlappingPromotionRulesCount/2;
+    }
+
+    private static IEnumerable<int> OverLappingRulesIndices(this IEnumerable<PromotionRule> appliedPromotionRulesQuery, PromotionRule rule)
+    {
+        var overlappingRulesIndices = appliedPromotionRulesQuery
+        .Where(x => appliedPromotionRulesQuery.ToList<PromotionRule>().IndexOf(rule) != appliedPromotionRulesQuery.ToList<PromotionRule>().IndexOf(x))
+        .Where(x => x.Items.Where(x => x != null).Intersect(rule.Items).Count() > 0)
+        .Select(x => appliedPromotionRulesQuery.ToList<PromotionRule>().IndexOf(x));
+
+        // var rulesIndicesExceptOneRuleQuery = appliedPromotionRulesQuery.Where(x => appliedPromotionRulesQuery.ToList<PromotionRule>().IndexOf(rule) != appliedPromotionRulesQuery.ToList<PromotionRule>().IndexOf(x));
+        // var countExceptRule = rulesIndicesExceptOneRuleQuery.Count();
+        // var overlappingRulesIndicesExceptOneRuleQuery = rulesIndicesExceptOneRuleQuery.Where(x => x.Items.Where(x => x != null).Intersect(rule.Items).Count() > 0);
+        // var countOverlap = overlappingRulesIndicesExceptOneRuleQuery.Count();
+        // var overlappingRulesIndicesQuery = overlappingRulesIndicesExceptOneRuleQuery.Select(x => appliedPromotionRulesQuery.ToList<PromotionRule>().IndexOf(x));
+        // var doesQueriesMatch = overlappingRulesIndicesQuery.SequenceEqual(overlappingRulesIndices);
+        return overlappingRulesIndices;
     }
 
     public static void MaxSavings()

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -57,7 +57,7 @@ public static class RuleOverlapAlgo
         int idxRule;
         PromotionRule rule;
         string skuConsumed = "";
-        string ruleSkuConsumed = "";
+        
         string ruleItems;
         foreach (var ruleAppliedCount in rulesAppliedCount)
         {
@@ -72,6 +72,7 @@ public static class RuleOverlapAlgo
                 if (rule.Items.Contains(null))
                     multiplyFactor *= rule.IdxProduct_j;
 
+                string ruleSkuConsumed = "";
                 foreach (var ite in Enumerable.Range(0, multiplyFactor))
                     ruleSkuConsumed = String.Format("{0},{1}", ruleSkuConsumed, ruleItems);
                 skuConsumed = String.Format("{0},{1}", skuConsumed, ruleSkuConsumed);

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -15,10 +15,17 @@ public static class RuleOverlapAlgo
     public static IEnumerable<int> OptimizeRulesApplied(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
     {
         List<int> promotionRulesAppliedCount = new List<int>(new int[promotionRules.Count()]);
+        List<PromotionRule> promotionRulesApplied = new List<PromotionRule>(promotionRules.Count());
         foreach (var rule in promotionRules)
         {
             // Todo: implement logic that prevents overlap and optimizes the total savings
-            promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
+            // Simple check would be that if rule has overlap with earlier added rule, then skip.
+            if (promotionRulesApplied.OverLappingRulesIndices(rule).Count() == 0)
+            {
+                promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
+                if (rule.PromotionOccurences(countsSKU) > 0)
+                    promotionRulesApplied.Add(rule);
+            }
         }
         return promotionRulesAppliedCount;
     }
@@ -64,7 +71,7 @@ public static class RuleOverlapAlgo
         // var overlappingRulesIndicesExceptOneRuleQuery = rulesIndicesExceptOneRuleQuery.Where(x => x.Items.Where(x => x != null).Intersect(rule.Items).Count() > 0);
         // var countOverlap = overlappingRulesIndicesExceptOneRuleQuery.Count();
         // var overlappingRulesIndicesQuery = overlappingRulesIndicesExceptOneRuleQuery.Select(x => appliedPromotionRulesQuery.ToList<PromotionRule>().IndexOf(x));
-        // var doesQueriesMatch = overlappingRulesIndicesQuery.SequenceEqual(overlappingRulesIndices);
+        // var doQueriesMatch = overlappingRulesIndicesQuery.SequenceEqual(overlappingRulesIndices);
         return overlappingRulesIndices;
     }
 

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -4,32 +4,22 @@ public static class RuleOverlapAlgo
 {
     public static IEnumerable<int> NonOptimizeRulesApplied(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
     {
-        // Todo: count every time a rule is applied. Find index of promotion rule in list PromotionRules and add 1 foreach time it is applied
-        // How to use something like PromotionRules.IndexOf(promotionRule) would probably be the right way since,
-        // List<PromotionRule>? PromotionRules
-
         List<int> promotionRulesAppliedCount = new List<int>(new int[promotionRules.Count()]);
         foreach (var rule in promotionRules)
         {
             promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
         }
-
         return promotionRulesAppliedCount;
     }
 
     public static IEnumerable<int> OptimizeRulesApplied(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
     {
-        // Todo: count every time a rule is applied. Find index of promotion rule in list PromotionRules and add 1 foreach time it is applied
-        // How to use something like PromotionRules.IndexOf(promotionRule) would probably be the right way since,
-        // List<PromotionRule>? PromotionRules
-
         List<int> promotionRulesAppliedCount = new List<int>(new int[promotionRules.Count()]);
         foreach (var rule in promotionRules)
         {
             // Todo: implement logic that prevents overlap and optimizes the total savings
             promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
         }
-
         return promotionRulesAppliedCount;
     }
 

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -2,6 +2,21 @@
 namespace Promotion.Engine.Library;
 public static class RuleOverlapAlgo
 {
+    public static IEnumerable<int> NonOptimizeRulesApplied(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
+    {
+        // Todo: count every time a rule is applied. Find index of promotion rule in list PromotionRules and add 1 foreach time it is applied
+        // How to use something like PromotionRules.IndexOf(promotionRule) would probably be the right way since,
+        // List<PromotionRule>? PromotionRules
+
+        List<int> promotionRulesAppliedCount = new List<int>(new int[promotionRules.Count()]);
+        foreach (var rule in promotionRules)
+        {
+            promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
+        }
+
+        return promotionRulesAppliedCount;
+    }
+
     public static IEnumerable<int> OptimizeRulesApplied(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
     {
         // Todo: count every time a rule is applied. Find index of promotion rule in list PromotionRules and add 1 foreach time it is applied
@@ -11,6 +26,7 @@ public static class RuleOverlapAlgo
         List<int> promotionRulesAppliedCount = new List<int>(new int[promotionRules.Count()]);
         foreach (var rule in promotionRules)
         {
+            // Todo: implement logic that prevents overlap and optimizes the total savings
             promotionRulesAppliedCount[promotionRules.ToList<PromotionRule>().IndexOf(rule)] = rule.PromotionOccurences(countsSKU);
         }
 

--- a/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
+++ b/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
@@ -307,8 +307,8 @@ public class UnitTestPromotionEngineLibrary
         IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
         var counts = stockKeepingUnits.CountSKU();
 
-        List<int> rulesAppliedCount = counts.OptimizeRulesApplied();
-        var overlaps = OverlappingPromotionRules(rulesAppliedCount);
+        IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied();
+        var overlaps = rulesAppliedCount.OverlappingPromotionRules();
         var expectedOverlaps = 0;
         var result = overlaps == expectedOverlaps;
         Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));

--- a/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
+++ b/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
@@ -290,4 +290,24 @@ public class UnitTestPromotionEngineLibrary
         // Todo: Assert.Fail() will display output lines written to console.
         // Assert.Fail();
     }
+
+    [Test]
+    public void TestOverlappingPromotionRules()
+    {
+        // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
+        // f: x --> number of times multiple rules overlapped 
+    }
+
+    [Test]
+    public void TestMaxSavings()
+    {
+        // Todo: maximize savings and find x_0 which satifies f(x_0)=0 and g(x_0)=max(g(x)) where g maps to total amount saved
+    }
+
+    [Test]
+    public void TestOverlappingPromotionRulesAndMaxSavings()
+    {
+        // Todo: Create algo that both satifies 0 overlapping promotion rules applied and max savings corresponding to accumulated
+        // savings from applied promotion rules
+    }
 }

--- a/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
+++ b/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
@@ -296,6 +296,22 @@ public class UnitTestPromotionEngineLibrary
     {
         // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
         // f: x --> number of times multiple rules overlapped 
+
+        // Outcommented since to general as first step
+        // var cartSize = 10;
+        // IEnumerable<string> randomSKU = new List<string>(new string[cartSize]);
+        // Random random = new Random();
+        // randomSKU = randomSKU.Select(x => PromotionEngineLibrary.ProductList.ToList<string>()[random.Next(cartSize)]);
+        // var counts = randomSKU.CountSKU();
+
+        IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
+        var counts = stockKeepingUnits.CountSKU();
+
+        List<int> rulesAppliedCount = counts.OptimizeRulesApplied();
+        var overlaps = OverlappingPromotionRules(rulesAppliedCount);
+        var expectedOverlaps = 0;
+        var result = overlaps == expectedOverlaps;
+        Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
     }
 
     [Test]

--- a/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
+++ b/PromotionEngineLibraryTest/UnitTestPromotionEngineLibrary.cs
@@ -290,40 +290,4 @@ public class UnitTestPromotionEngineLibrary
         // Todo: Assert.Fail() will display output lines written to console.
         // Assert.Fail();
     }
-
-    [Test]
-    public void TestOverlappingPromotionRules()
-    {
-        // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
-        // f: x --> number of times multiple rules overlapped 
-
-        // Outcommented since to general as first step
-        // var cartSize = 10;
-        // IEnumerable<string> randomSKU = new List<string>(new string[cartSize]);
-        // Random random = new Random();
-        // randomSKU = randomSKU.Select(x => PromotionEngineLibrary.ProductList.ToList<string>()[random.Next(cartSize)]);
-        // var counts = randomSKU.CountSKU();
-
-        IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
-        var counts = stockKeepingUnits.CountSKU();
-
-        IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied();
-        var overlaps = rulesAppliedCount.OverlappingPromotionRules();
-        var expectedOverlaps = 0;
-        var result = overlaps == expectedOverlaps;
-        Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
-    }
-
-    [Test]
-    public void TestMaxSavings()
-    {
-        // Todo: maximize savings and find x_0 which satifies f(x_0)=0 and g(x_0)=max(g(x)) where g maps to total amount saved
-    }
-
-    [Test]
-    public void TestOverlappingPromotionRulesAndMaxSavings()
-    {
-        // Todo: Create algo that both satifies 0 overlapping promotion rules applied and max savings corresponding to accumulated
-        // savings from applied promotion rules
-    }
 }

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -26,9 +26,23 @@ public class UnitTestRuleOverlapAlgo
         IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
         var counts = stockKeepingUnits.CountSKU();
 
-        IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied();
-        var overlaps = rulesAppliedCount.OverlappingPromotionRules();
-        var expectedOverlaps = 0;
+        List<PromotionRule> promotionRules = new List<PromotionRule>();
+
+        // Create Promotion rule
+        int price = 130;
+        int nItems = 3;
+        string item_i = "B";
+        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
+
+        // Create Promotion rule
+        price = 45;
+        nItems = 2;
+        item_i = "B";
+        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
+
+        IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);
+        var overlaps = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
+        var expectedOverlaps = 1;
         var result = overlaps == expectedOverlaps;
         Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
     }

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -100,13 +100,13 @@ public class UnitTestRuleOverlapAlgo
         // Act
         IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);
         var overlapsRules = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
-        var overlapsSKU = RuleOverlapAlgo.OverlappingSKUConsumptionInRules();
+        var overlapsSKU = rulesAppliedCount.OverlappingSKUConsumptionInRules(promotionRules, counts);
 
         // Assert
         var expectedOverlapsRules = 1;
         var expectedOverlapsSKU = 0;
         var result = overlapsSKU == expectedOverlapsSKU & overlapsRules == expectedOverlapsRules;
-        Assert.True(result, String.Format("Expected number of times rules applied to same SKU'{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlapsSKU, overlapsSKU, result));
+        Assert.True(result, String.Format("Expected number of overlapping SKUs after applied rules '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlapsSKU, overlapsSKU, result));
     }
 
     [Test]

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -13,7 +13,7 @@ public class UnitTestRuleOverlapAlgo
     }
   
    [Test]
-    public void TestNonOptimizedOverlappingPromotionRules()
+    public void NonOptimizeRulesApplied_TwoOverlappingPromotionRules_ExpectOneOverlap()
     {
         // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
         // f: x --> number of times multiple rules overlapped 
@@ -50,7 +50,7 @@ public class UnitTestRuleOverlapAlgo
     }
 
     [Test]
-    public void TestOptimizedOverlappingPromotionRules()
+    public void OptimizeRulesApplied_TwoOverlappingPromotionRules_ExpectZeroOverlap()
     {
         // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
         // f: x --> number of times multiple rules overlapped 
@@ -88,13 +88,13 @@ public class UnitTestRuleOverlapAlgo
 
 
     [Test]
-    public void TestMaxSavings()
+    public void MaxSavings_TwoOverlappingPromotionRules_ExpectHigherSavingsThanRandomSelectionOfAppliedOverlappingPromotionRules()
     {
         // Todo: maximize savings and find x_0 which satifies f(x_0)=0 and g(x_0)=max(g(x)) where g maps to total amount saved
     }
 
     [Test]
-    public void TestOverlappingPromotionRulesAndMaxSavings()
+    public void OptimizeRulesAppliedAndMaxSavings_TwoOverlappingPromotionRules_ExpectHigherSavingsThanMaxSavingsWithAppliedOverlappingPromotionRules()
     {
         // Todo: Create algo that both satifies 0 overlapping promotion rules applied and max savings corresponding to accumulated
         // savings from applied promotion rules

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -12,10 +12,8 @@ public class UnitTestRuleOverlapAlgo
     {
     }
   
-    private IEnumerable<PromotionRule> Create2OverlappingPromotionRules()
+    private static void Create2OverlappingPromotionRules(List<PromotionRule> promotionRules)
     {
-        List<PromotionRule> promotionRules = new List<PromotionRule>();
-
         // Create Promotion rule
         int price = 130;
         int nItems = 3;
@@ -27,9 +25,23 @@ public class UnitTestRuleOverlapAlgo
         nItems = 2;
         item_i = "B";
         promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
-
-        return promotionRules;
     }
+
+    private static void Create2NonOverlappingPromotionRules(List<PromotionRule> promotionRules)
+    {
+        // Create Promotion rule
+        int price = 130;
+        int nItems = 3;
+        string item_i = "A";
+        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
+
+        // Create Promotion rule
+        price = 30;
+        item_i = "C";
+        string item_j = "D";
+        promotionRules.CreatePromotion2ItemsForFixedPrice(item_i, item_j, price);
+    }
+
 
     [Test]
     public void NonOptimizeRulesApplied_TwoOverlappingPromotionRules_OneOverlap()
@@ -40,7 +52,8 @@ public class UnitTestRuleOverlapAlgo
         // Arrange
         IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
         var counts = stockKeepingUnits.CountSKU();
-        List<PromotionRule> promotionRules = (List<PromotionRule>)Create2OverlappingPromotionRules();
+        List<PromotionRule> promotionRules = new List<PromotionRule>();
+        Create2OverlappingPromotionRules(promotionRules);
 
         // Act
         IEnumerable<int> rulesAppliedCount = counts.NonOptimizeRulesApplied(promotionRules);
@@ -61,7 +74,9 @@ public class UnitTestRuleOverlapAlgo
         // Arrange
         IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
         var counts = stockKeepingUnits.CountSKU();
-        IEnumerable<PromotionRule> promotionRules = Create2OverlappingPromotionRules();
+        List<PromotionRule> promotionRules = new List<PromotionRule>();
+        Create2OverlappingPromotionRules(promotionRules);
+        Create2NonOverlappingPromotionRules(promotionRules);
 
         // Act
         IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -1,8 +1,10 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using Promotion.Engine.Library;
 
-namespace Promotion.Engine.Library.Test;
+namespace Promotion.Engine.UnitTests.Library;
+[TestFixture]
 public class UnitTestRuleOverlapAlgo
 {
     [SetUp]

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -12,22 +12,8 @@ public class UnitTestRuleOverlapAlgo
     {
     }
   
-   [Test]
-    public void NonOptimizeRulesApplied_TwoOverlappingPromotionRules_OneOverlap()
+    private IEnumerable<PromotionRule> Create2OverlappingPromotionRules()
     {
-        // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
-        // f: x --> number of times multiple rules overlapped 
-
-        // Outcommented since to general as first step
-        // var cartSize = 10;
-        // IEnumerable<string> randomSKU = new List<string>(new string[cartSize]);
-        // Random random = new Random();
-        // randomSKU = randomSKU.Select(x => PromotionEngineLibrary.ProductList.ToList<string>()[random.Next(cartSize)]);
-        // var counts = randomSKU.CountSKU();
-
-        IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
-        var counts = stockKeepingUnits.CountSKU();
-
         List<PromotionRule> promotionRules = new List<PromotionRule>();
 
         // Create Promotion rule
@@ -41,6 +27,20 @@ public class UnitTestRuleOverlapAlgo
         nItems = 2;
         item_i = "B";
         promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
+
+        return promotionRules;
+    }
+
+    [Test]
+    public void NonOptimizeRulesApplied_TwoOverlappingPromotionRules_OneOverlap()
+    {
+        // Find f(x)=1 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
+        // f: x --> number of times multiple rules overlapped
+
+        IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
+        var counts = stockKeepingUnits.CountSKU();
+
+        List<PromotionRule> promotionRules = (List<PromotionRule>)Create2OverlappingPromotionRules();
 
         IEnumerable<int> rulesAppliedCount = counts.NonOptimizeRulesApplied(promotionRules);
         var overlaps = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
@@ -52,32 +52,13 @@ public class UnitTestRuleOverlapAlgo
     [Test]
     public void OptimizeRulesApplied_TwoOverlappingPromotionRules_ZeroOverlap()
     {
-        // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
-        // f: x --> number of times multiple rules overlapped 
-
-        // Outcommented since to general as first step
-        // var cartSize = 10;
-        // IEnumerable<string> randomSKU = new List<string>(new string[cartSize]);
-        // Random random = new Random();
-        // randomSKU = randomSKU.Select(x => PromotionEngineLibrary.ProductList.ToList<string>()[random.Next(cartSize)]);
-        // var counts = randomSKU.CountSKU();
+        // Find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
+        // f: x --> number of times multiple rules overlapped
 
         IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
         var counts = stockKeepingUnits.CountSKU();
 
-        List<PromotionRule> promotionRules = new List<PromotionRule>();
-
-        // Create Promotion rule
-        int price = 130;
-        int nItems = 3;
-        string item_i = "B";
-        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
-
-        // Create Promotion rule
-        price = 45;
-        nItems = 2;
-        item_i = "B";
-        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
+        IEnumerable<PromotionRule> promotionRules = Create2OverlappingPromotionRules();
 
         IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);
         var overlaps = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
@@ -85,7 +66,6 @@ public class UnitTestRuleOverlapAlgo
         var result = overlaps == expectedOverlaps;
         Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
     }
-
 
     [Test]
     public void MaxSavings_TwoOverlappingPromotionRules_HigherSavingsThanForRandomSelectionOfAppliedOverlappingPromotionRules()

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -100,7 +100,7 @@ public class UnitTestRuleOverlapAlgo
         // Act
         IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);
         var overlapsRules = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
-        var overlapsSKU = rulesAppliedCount.OverlappingSKUConsumptionInRules(promotionRules, counts);
+        var overlapsSKU = rulesAppliedCount.OverlappingSKUConsumptionInRulesSum(promotionRules, counts);
 
         // Assert
         var expectedOverlapsRules = 1;

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -37,13 +37,16 @@ public class UnitTestRuleOverlapAlgo
         // Find f(x)=1 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
         // f: x --> number of times multiple rules overlapped
 
+        // Arrange
         IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
         var counts = stockKeepingUnits.CountSKU();
-
         List<PromotionRule> promotionRules = (List<PromotionRule>)Create2OverlappingPromotionRules();
 
+        // Act
         IEnumerable<int> rulesAppliedCount = counts.NonOptimizeRulesApplied(promotionRules);
         var overlaps = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
+
+        // Assert
         var expectedOverlaps = 1;
         var result = overlaps == expectedOverlaps;
         Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
@@ -55,13 +58,16 @@ public class UnitTestRuleOverlapAlgo
         // Find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
         // f: x --> number of times multiple rules overlapped
 
+        // Arrange
         IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
         var counts = stockKeepingUnits.CountSKU();
-
         IEnumerable<PromotionRule> promotionRules = Create2OverlappingPromotionRules();
 
+        // Act
         IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);
         var overlaps = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
+
+        // Assert
         var expectedOverlaps = 0;
         var result = overlaps == expectedOverlaps;
         Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
@@ -71,6 +77,10 @@ public class UnitTestRuleOverlapAlgo
     public void MaxSavings_TwoOverlappingPromotionRules_HigherSavingsThanForRandomSelectionOfAppliedOverlappingPromotionRules()
     {
         // Todo: maximize savings and find x_0 which satifies f(x_0)=0 and g(x_0)=max(g(x)) where g maps to total amount saved
+
+        // Arrange
+        // Act
+        // Assert
     }
 
     [Test]
@@ -78,5 +88,10 @@ public class UnitTestRuleOverlapAlgo
     {
         // Todo: Create algo that both satifies 0 overlapping promotion rules applied and max savings corresponding to accumulated
         // savings from applied promotion rules
+
+        // Arrange
+        // Act
+        // Assert
+
     }
 }

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -89,7 +89,7 @@ public class UnitTestRuleOverlapAlgo
     }
 
     [Test]
-    public void OverlappingSKUConsumptionInRules_TwoOverlappingPromotionRules_ZeroOverlappingSKUAndBothOverlappingRulesApplied()
+    public void SKUConsumptionInRulesSum_TwoOverlappingPromotionRules_ZeroOverlappingSKUAndBothOverlappingRulesApplied()
     {
         // Arrange
         IEnumerable<string> stockKeepingUnits = new List<string>{"B", "B", "B", "B", "B"};
@@ -100,7 +100,7 @@ public class UnitTestRuleOverlapAlgo
         // Act
         IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);
         var overlapsRules = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
-        var overlapsSKU = rulesAppliedCount.OverlappingSKUConsumptionInRulesSum(promotionRules, counts);
+        var overlapsSKU = rulesAppliedCount.SKUConsumptionInRulesSum(promotionRules, counts);
 
         // Assert
         var expectedOverlapsRules = 1;

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -11,7 +11,44 @@ public class UnitTestRuleOverlapAlgo
     }
   
    [Test]
-    public void TestOverlappingPromotionRules()
+    public void TestNonOptimizedOverlappingPromotionRules()
+    {
+        // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
+        // f: x --> number of times multiple rules overlapped 
+
+        // Outcommented since to general as first step
+        // var cartSize = 10;
+        // IEnumerable<string> randomSKU = new List<string>(new string[cartSize]);
+        // Random random = new Random();
+        // randomSKU = randomSKU.Select(x => PromotionEngineLibrary.ProductList.ToList<string>()[random.Next(cartSize)]);
+        // var counts = randomSKU.CountSKU();
+
+        IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
+        var counts = stockKeepingUnits.CountSKU();
+
+        List<PromotionRule> promotionRules = new List<PromotionRule>();
+
+        // Create Promotion rule
+        int price = 130;
+        int nItems = 3;
+        string item_i = "B";
+        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
+
+        // Create Promotion rule
+        price = 45;
+        nItems = 2;
+        item_i = "B";
+        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
+
+        IEnumerable<int> rulesAppliedCount = counts.NonOptimizeRulesApplied(promotionRules);
+        var overlaps = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
+        var expectedOverlaps = 1;
+        var result = overlaps == expectedOverlaps;
+        Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
+    }
+
+    [Test]
+    public void TestOptimizedOverlappingPromotionRules()
     {
         // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
         // f: x --> number of times multiple rules overlapped 
@@ -42,10 +79,11 @@ public class UnitTestRuleOverlapAlgo
 
         IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);
         var overlaps = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
-        var expectedOverlaps = 1;
+        var expectedOverlaps = 0;
         var result = overlaps == expectedOverlaps;
         Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
     }
+
 
     [Test]
     public void TestMaxSavings()

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -13,7 +13,7 @@ public class UnitTestRuleOverlapAlgo
     }
   
    [Test]
-    public void NonOptimizeRulesApplied_TwoOverlappingPromotionRules_ExpectOneOverlap()
+    public void NonOptimizeRulesApplied_TwoOverlappingPromotionRules_OneOverlap()
     {
         // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
         // f: x --> number of times multiple rules overlapped 
@@ -50,7 +50,7 @@ public class UnitTestRuleOverlapAlgo
     }
 
     [Test]
-    public void OptimizeRulesApplied_TwoOverlappingPromotionRules_ExpectZeroOverlap()
+    public void OptimizeRulesApplied_TwoOverlappingPromotionRules_ZeroOverlap()
     {
         // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
         // f: x --> number of times multiple rules overlapped 
@@ -88,13 +88,13 @@ public class UnitTestRuleOverlapAlgo
 
 
     [Test]
-    public void MaxSavings_TwoOverlappingPromotionRules_ExpectHigherSavingsThanRandomSelectionOfAppliedOverlappingPromotionRules()
+    public void MaxSavings_TwoOverlappingPromotionRules_HigherSavingsThanForRandomSelectionOfAppliedOverlappingPromotionRules()
     {
         // Todo: maximize savings and find x_0 which satifies f(x_0)=0 and g(x_0)=max(g(x)) where g maps to total amount saved
     }
 
     [Test]
-    public void OptimizeRulesAppliedAndMaxSavings_TwoOverlappingPromotionRules_ExpectHigherSavingsThanMaxSavingsWithAppliedOverlappingPromotionRules()
+    public void OptimizeRulesAppliedAndMaxSavings_TwoOverlappingPromotionRules_HigherSavingsThanForMaxSavingsWithAppliedOverlappingPromotionRules()
     {
         // Todo: Create algo that both satifies 0 overlapping promotion rules applied and max savings corresponding to accumulated
         // savings from applied promotion rules

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace Promotion.Engine.Library.Test;
+public class UnitTestRuleOverlapAlgo
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+  
+   [Test]
+    public void TestOverlappingPromotionRules()
+    {
+        // Todo: find f(x)=0 where x = {times_rule_1_applied, times_rule_2_applied, .., times_rule_n_applied}
+        // f: x --> number of times multiple rules overlapped 
+
+        // Outcommented since to general as first step
+        // var cartSize = 10;
+        // IEnumerable<string> randomSKU = new List<string>(new string[cartSize]);
+        // Random random = new Random();
+        // randomSKU = randomSKU.Select(x => PromotionEngineLibrary.ProductList.ToList<string>()[random.Next(cartSize)]);
+        // var counts = randomSKU.CountSKU();
+
+        IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "B", "B", "B", "B", "B", "C", "D"};
+        var counts = stockKeepingUnits.CountSKU();
+
+        IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied();
+        var overlaps = rulesAppliedCount.OverlappingPromotionRules();
+        var expectedOverlaps = 0;
+        var result = overlaps == expectedOverlaps;
+        Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
+    }
+
+    [Test]
+    public void TestMaxSavings()
+    {
+        // Todo: maximize savings and find x_0 which satifies f(x_0)=0 and g(x_0)=max(g(x)) where g maps to total amount saved
+    }
+
+    [Test]
+    public void TestOverlappingPromotionRulesAndMaxSavings()
+    {
+        // Todo: Create algo that both satifies 0 overlapping promotion rules applied and max savings corresponding to accumulated
+        // savings from applied promotion rules
+    }
+}

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -83,7 +83,7 @@ public class UnitTestRuleOverlapAlgo
         var overlaps = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
 
         // Assert
-        var expectedOverlaps = 0;
+        var expectedOverlaps = 1;
         var result = overlaps == expectedOverlaps;
         Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
     }

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -21,7 +21,7 @@ public class UnitTestRuleOverlapAlgo
         promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
 
         // Create Promotion rule
-        price = 45;
+        price = 90;
         nItems = 2;
         item_i = "B";
         promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
@@ -86,6 +86,27 @@ public class UnitTestRuleOverlapAlgo
         var expectedOverlaps = 0;
         var result = overlaps == expectedOverlaps;
         Assert.True(result, String.Format("Expected number of times multiple rules overlapped '{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlaps, overlaps, result));
+    }
+
+    [Test]
+    public void OverlappingSKUConsumptionInRules_TwoOverlappingPromotionRules_ZeroOverlappingSKUAndBothOverlappingRulesApplied()
+    {
+        // Arrange
+        IEnumerable<string> stockKeepingUnits = new List<string>{"B", "B", "B", "B", "B"};
+        var counts = stockKeepingUnits.CountSKU();
+        List<PromotionRule> promotionRules = new List<PromotionRule>();
+        Create2OverlappingPromotionRules(promotionRules);
+
+        // Act
+        IEnumerable<int> rulesAppliedCount = counts.OptimizeRulesApplied(promotionRules);
+        var overlapsRules = rulesAppliedCount.OverlappingPromotionRules(promotionRules);
+        var overlapsSKU = RuleOverlapAlgo.OverlappingSKUConsumptionInRules();
+
+        // Assert
+        var expectedOverlapsRules = 1;
+        var expectedOverlapsSKU = 0;
+        var result = overlapsSKU == expectedOverlapsSKU & overlapsRules == expectedOverlapsRules;
+        Assert.True(result, String.Format("Expected number of times rules applied to same SKU'{0}': true, and actual overlap count '{1}': '{2}'", expectedOverlapsSKU, overlapsSKU, result));
     }
 
     [Test]


### PR DESCRIPTION
Description: previously the promotion engine assumed all promotion rules to be independent. In the case of two rules that overlapped a wrong total price would be computed. Now a new algo handles the case of overlapping promotion rules, which are rules that at least have one identical SKU in common in their definitions. The new algo implements a state for countsSKU from which each applied rule consumes SKU, such that a later applied rule only consumes from non-used SKUs. The overlap algo is not optimized for total price savings which is the focus of a future PR, but instead it applies promotion rules in a sequential order until all SKUs have been consumed.