### PR TITLE
Fix thrown exception by adding check on rulesAppliedCount for all zer…

### DIFF
--- a/PromotionEngineLibrary/PromotionEngine.cs
+++ b/PromotionEngineLibrary/PromotionEngine.cs
@@ -28,6 +28,9 @@ public static class PromotionEngineLibrary
     {
         IList<int> counts = new List<int>(new int[ProductList.Count()]);
 
+        if (sku != null && sku.All(x => x == ""))
+            return counts;
+
         // In order to sort by products in ProductList add the elements in ProductList to sku and subtract 1 occurence afterwards
         List<string> skuWithAddedProductList = sku?.ToList<string>() ?? throw new ArgumentNullException("Parameter needs to be set", nameof(sku));
         skuWithAddedProductList.AddRange(ProductList);

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -27,7 +27,7 @@ public static class RuleOverlapAlgo
             // Reset list with 0s
             var countsOnlyByAppliedRule = new List<int>(new int[promotionRules.Count()]);
             countsOnlyByAppliedRule[idxRule] = rule.PromotionOccurences(countsSKUState);
-            var countsConsumed = countsOnlyByAppliedRule.SKUConsumptionInRules(promotionRules, countsSKUState);
+            var countsConsumed = countsOnlyByAppliedRule.SKUConsumptionInRules(promotionRules);
 
             countsSKUSubtractedConsumedSKU = SubtractConsumedCounts(countsSKUState, countsConsumed);
 
@@ -73,10 +73,17 @@ public static class RuleOverlapAlgo
         return overlappingPromotionRulesCount/2;
     }
 
-    public static IEnumerable<int> SKUConsumptionInRules(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
+    public static IEnumerable<int> SKUConsumptionInRules(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules)
     {
         // Todo: for each applied promotion rule use number of times it was applied in rulesAppliedCount together 
         // with Items member of a promotion to compute sum of SKU consumption that should not be larger than actual countsSKU
+        if (rulesAppliedCount.All(x => x == 0))
+        {
+            IList<int> counts = new List<int>(new int[PromotionEngineLibrary.ProductList.Count()]);
+            return counts;
+            // throw new ArgumentException("Parameter only has zeros", nameof(rulesAppliedCount));
+        }
+
         int idxRule = 0;
         PromotionRule rule;
         string skuConsumed = "";
@@ -109,7 +116,7 @@ public static class RuleOverlapAlgo
 
     public static int SKUConsumptionInRulesSum(this IEnumerable<int> rulesAppliedCount, IEnumerable<PromotionRule> promotionRules, IEnumerable<int> countsSKU)
     {
-        var appliedRulesSKUcounts = rulesAppliedCount.SKUConsumptionInRules(promotionRules, countsSKU);
+        var appliedRulesSKUcounts = rulesAppliedCount.SKUConsumptionInRules(promotionRules);
         var diff = appliedRulesSKUcounts.Select(x => x - countsSKU.ToList().ElementAt(appliedRulesSKUcounts.ToList<int>().IndexOf(x)));
         return diff.Sum();
     }


### PR DESCRIPTION
…o case in method SKUConsumptionInRules(). Remove redundant input arg in same method. Fix same propagated exception for case of empty string input in method CountSKU()