### PR TITLE
Feature algo max savings

### DIFF
--- a/PromotionEngineLibrary/PromotionEngine.cs
+++ b/PromotionEngineLibrary/PromotionEngine.cs
@@ -121,20 +121,21 @@ public static class PromotionEngineLibrary
 
     public static int TotalPriceUsingPromotionRules(this IEnumerable<int>? counts, IEnumerable<PromotionRule> promotionRules)
     {
+        int priceWithoutPromotion = TotalPriceNoPromotions(counts);
+        int savings;
+        RuleOverlapAlgo.SavingsOfRulePermuation(counts, out savings, promotionRules);
+        return priceWithoutPromotion - savings;
+    }
+
+    public static int TotalPriceNoPromotions(IEnumerable<int>? counts)
+    {
         int priceWithoutPromotion = 0;
         if (counts == null)
-            throw new ArgumentNullException("Parameter needs to be set", nameof(counts));   
-        
+            throw new ArgumentNullException("Parameter needs to be set", nameof(counts));
+
         foreach (var ite in Enumerable.Range(0, counts.Count()))
-            priceWithoutPromotion += counts.ElementAt(ite)*Prices.ElementAt(ite);
-
-        var totalPromotionSaving = 0;
-        foreach (var rule in promotionRules)
-        {
-            totalPromotionSaving += rule.TotalPromotionSaving(counts);
-        }
-
-        return priceWithoutPromotion - totalPromotionSaving;
+            priceWithoutPromotion += counts.ElementAt(ite) * Prices.ElementAt(ite);
+        return priceWithoutPromotion;
     }
 
     public static void Add3PromotionRules(List<PromotionRule> promotionRules)

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -139,7 +139,6 @@ public static class RuleOverlapAlgo
 
     public static IEnumerable<int> MaxSavings(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
     {
-        // Returns true if application of rule maximizes savings in total price
         // Builds on top of method OptimizeRulesApplied() so it solves also OptimizeRulesAppliedAndMaxSavings(), but MaxSavings() is a better name since OptimizeRulesApplied() 
         // is more an underlying optimization.
         // First simple solution: It should first try out all sequence combinations of rules which for n rules amounts to n! combinations

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -155,13 +155,19 @@ public static class RuleOverlapAlgo
         List<int> maxSavings;
         SavingsForAllPermutationsOfRules(countsSKU, permutationsRules, out maxSavings);
 
-        var maxIdx = maxSavings.IndexOf(maxSavings.Max());
-        var rulePermMaxSaving = permutationsRules.ToList<IEnumerable<PromotionRule>>()[maxIdx];
+        IEnumerable<PromotionRule> rulePermMaxSaving = RulePermutationMaxSavings(permutationsRules, maxSavings);
         var rulesAppliedCountMaxSavings = countsSKU.OptimizeRulesApplied(rulePermMaxSaving);
 
         List<int> rulesAppliedCountMaxSavingsOrdered = RulesAppliedCountOrdered(promotionRules, rulePermMaxSaving, rulesAppliedCountMaxSavings);
 
         return rulesAppliedCountMaxSavingsOrdered;
+    }
+
+    public static IEnumerable<PromotionRule> RulePermutationMaxSavings(IEnumerable<IEnumerable<PromotionRule>> permutationsRules, List<int> maxSavings)
+    {
+        var maxIdx = maxSavings.IndexOf(maxSavings.Max());
+        var rulePermMaxSaving = permutationsRules.ToList<IEnumerable<PromotionRule>>()[maxIdx];
+        return rulePermMaxSaving;
     }
 
     private static List<int> RulesAppliedCountOrdered(IEnumerable<PromotionRule> promotionRulesOrdered, IEnumerable<PromotionRule> rulePermutationUnordered, IEnumerable<int> rulesAppliedCountMaxSavings)
@@ -177,7 +183,7 @@ public static class RuleOverlapAlgo
         return rulesAppliedCountOrdered;
     }
 
-    private static void SavingsForAllPermutationsOfRules(IEnumerable<int> countsSKU, IEnumerable<IEnumerable<PromotionRule>> permutationsRules, out List<int> maxSavings)
+    public static void SavingsForAllPermutationsOfRules(IEnumerable<int> countsSKU, IEnumerable<IEnumerable<PromotionRule>> permutationsRules, out List<int> maxSavings)
     {
         maxSavings = new List<int>(new int[permutationsRules.Count()]);
         var ite = 0;
@@ -191,8 +197,11 @@ public static class RuleOverlapAlgo
         }
     }
 
-    private static void SavingsOfRulePermuation(IEnumerable<int> countsSKU, out int savings, IEnumerable<PromotionRule> rulesPerm)
+    public static void SavingsOfRulePermuation(IEnumerable<int>? countsSKU, out int savings, IEnumerable<PromotionRule> rulesPerm)
     {
+        if (countsSKU == null)
+            throw new ArgumentNullException("Parameter needs to be set", nameof(countsSKU));
+
         var rulesAppliedCount = countsSKU.OptimizeRulesApplied(rulesPerm);
         savings = 0;
         var jte = 0;

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -137,8 +137,16 @@ public static class RuleOverlapAlgo
         return overlappingRulesIndices;
     }
 
-    public static void MaxSavings()
+    public static IEnumerable<int> MaxSavings(this IEnumerable<int> countsSKU, IEnumerable<PromotionRule> promotionRules)
     {
+        // Returns true if application of rule maximizes savings in total price
+        // Builds on top of method OptimizeRulesApplied() so it solves also OptimizeRulesAppliedAndMaxSavings(), but MaxSavings() is a better name since OptimizeRulesApplied() 
+        // is more an underlying optimization.
+        // First simple solution: It should first try out all sequence combinations of rules which for n rules amounts to n! combinations
+        // For each combination of rules in promotionRules it could call counts.OptimizeRulesApplied(promotionRules)
+        // Then for each of the returned rulesAppliedCount the total savings get computed
+        // finally the rulesAppliedCount leading to a max for total savings is selected
+        
         throw new NotImplementedException("Please create a test first.");
     }
 

--- a/PromotionEngineLibrary/RuleOverlapAlgo.cs
+++ b/PromotionEngineLibrary/RuleOverlapAlgo.cs
@@ -145,8 +145,43 @@ public static class RuleOverlapAlgo
         // For each combination of rules in promotionRules it could call counts.OptimizeRulesApplied(promotionRules)
         // Then for each of the returned rulesAppliedCount the total savings get computed
         // finally the rulesAppliedCount leading to a max for total savings is selected
-        
-        throw new NotImplementedException("Please create a test first.");
+
+        var permutationsRules = GetPermutations<PromotionRule>(promotionRules, promotionRules.Count());
+
+        var maxSavings = new List<int>(new int[permutationsRules.Count()]);
+
+        var ite = 0;
+        foreach (var rulesPerm in permutationsRules)
+        {
+            var rulesAppliedCount = countsSKU.OptimizeRulesApplied(rulesPerm);
+            var jte = 0;
+            foreach (var count in rulesAppliedCount)
+            {
+                maxSavings[ite] += rulesPerm.ToList<PromotionRule>()[jte].Saving*count;
+                jte++;
+            }
+            ite++;
+        }
+
+        var maxIdx = maxSavings.IndexOf(maxSavings.Max());
+        var rulePermMaxSaving = permutationsRules.ToList<IEnumerable<PromotionRule>>()[maxIdx];
+        var rulesAppliedCountMaxSavings = countsSKU.OptimizeRulesApplied(rulePermMaxSaving);
+        var inverseIdxRulesQuery = rulePermMaxSaving.Select(rule => promotionRules.ToList<PromotionRule>().IndexOf(rule)).ToList<int>();
+        var rulesAppliedCountMaxSavingsOrdered = new List<int>(new int[rulesAppliedCountMaxSavings.Count()]);
+        ite = 0;
+        foreach (var count in rulesAppliedCountMaxSavings)
+        {
+            rulesAppliedCountMaxSavingsOrdered[inverseIdxRulesQuery[ite]] = count;
+            ite++;
+        }
+        return rulesAppliedCountMaxSavingsOrdered;
+    }
+
+    public static IEnumerable<IEnumerable<T>> GetPermutations<T>(IEnumerable<T> list, int length)
+    {
+        if (length == 1)
+            return list.Select(t => new T[]{ t });
+        return GetPermutations(list, length - 1).SelectMany(t => list.Where(e => !t.Contains(e)), (t1, t2) => t1.Concat(new T[] { t2 }));
     }
 
     public static void OptimizeRulesAppliedAndMaxSavings()

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using Promotion.Engine.Library;
+using System.Linq;
 
 namespace Promotion.Engine.UnitTests.Library;
 [TestFixture]
@@ -115,8 +116,24 @@ public class UnitTestRuleOverlapAlgo
         // Todo: maximize savings and find x_0 which satifies f(x_0)=0 and g(x_0)=max(g(x)) where g maps to total amount saved
 
         // Arrange
+        IEnumerable<string> stockKeepingUnits = new List<string>{"B", "B", "B", "B", "B", "B"};
+        var counts = stockKeepingUnits.CountSKU();
+        List<PromotionRule> promotionRules = new List<PromotionRule>();
+        Create2OverlappingPromotionRules(promotionRules);
+        // Create Cheap Promotion rule
+        var price = 80;
+        var nItems = 3;
+        var item_i = "B";
+        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
+
         // Act
+        IEnumerable<int> maxSavingsRulesAppliedCount = counts.MaxSavings(promotionRules);
+
         // Assert
+        IEnumerable<int> expectedRulesAppliedCount = new List<int>{0,0,2};
+        var result = maxSavingsRulesAppliedCount.SequenceEqual(expectedRulesAppliedCount);
+        Assert.True(result, String.Format("Expected rules applied indices'{0}': true, and actual indices '{1}': '{2}'"
+            , String.Join(",", expectedRulesAppliedCount), String.Join(",", maxSavingsRulesAppliedCount), result));
     }
 
     [Test]

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -139,7 +139,7 @@ public class UnitTestRuleOverlapAlgo
         Create2OverlappingPromotionRules(promotionRules);
         // Create Cheapest Promotion rule
         var nItems = 3;
-        var price = nItems*PromotionEngineLibrary.PriceA - PromotionEngineLibrary.Promotion3AsSaving/2;
+        var price = nItems*PromotionEngineLibrary.PriceA - PromotionEngineLibrary.Promotion3AsSaving/3*4;
         var item_i = "A";
         promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
 
@@ -166,10 +166,41 @@ public class UnitTestRuleOverlapAlgo
         IEnumerable<int> maxSavingsRulesAppliedCount = counts.MaxSavings(promotionRules);
 
         // Assert
-        IEnumerable<int> expectedRulesAppliedCount = new List<int>{1,1};
+        IEnumerable<int> expectedRulesAppliedCount = new List<int>{1,2};
         var result = maxSavingsRulesAppliedCount.SequenceEqual(expectedRulesAppliedCount);
         Assert.True(result, String.Format("Expected rules applied indices'{0}': true, and actual indices '{1}': '{2}'"
             , String.Join(",", expectedRulesAppliedCount), String.Join(",", maxSavingsRulesAppliedCount), result));
+    }
+
+    private int Factorials(int number)
+    {
+        var result = 1;
+        for ( int x = 1; x <= number; x++)
+            result *= x;
+        return result;
+    }
+
+    private int FactorialsRecursive(int number)
+    {
+        if (number == 1)
+            return 1;
+        return number*FactorialsRecursive(number - 1);
+    }
+
+    [Test]
+    public void GetPermutations_RangeOf3Integers_CountOfAllPermutationsOf3Integers()
+    {
+        // Arrange
+        var input = Enumerable.Range(1, 3);
+
+        // Act
+        var permutationsQuery = RuleOverlapAlgo.GetPermutations(input, input.Count());
+
+        // Assert
+        var expected = FactorialsRecursive(input.Count());
+        var permutations = permutationsQuery.Count();
+        var result = permutations == expected;
+        Assert.True(result, String.Format("Expected permutations '{0}': true, and actual permuations count '{1}': '{2}'", expected, permutations, result));
     }
 
     [Test]

--- a/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
+++ b/PromotionEngineLibraryTest/UnitTestRuleOverlapAlgo.cs
@@ -204,14 +204,30 @@ public class UnitTestRuleOverlapAlgo
     }
 
     [Test]
-    public void OptimizeRulesAppliedAndMaxSavings_TwoOverlappingPromotionRules_HigherSavingsThanForMaxSavingsWithAppliedOverlappingPromotionRules()
+    public void TotalPriceUsingPromotionRules_MaxSavingsAlgoApplied_LowestTotatPriceForMaxSavingsAlgo()
     {
-        // Todo: Create algo that both satifies 0 overlapping promotion rules applied and max savings corresponding to accumulated
-        // savings from applied promotion rules
-
         // Arrange
-        // Act
-        // Assert
+        IEnumerable<string> stockKeepingUnits = new List<string>{"A", "A", "A", "A", "A", "A"};
+        var counts = stockKeepingUnits.CountSKU();
+        List<PromotionRule> promotionRules = new List<PromotionRule>();
+        Create2OverlappingPromotionRules(promotionRules);
+        // Create Cheapest Promotion rule
+        var nItems = 3;
+        var price = nItems*PromotionEngineLibrary.PriceA - PromotionEngineLibrary.Promotion3AsSaving/3*4;
+        var item_i = "A";
+        promotionRules.CreatePromotionNItemsForFixedPrice(nItems, item_i, price);
 
+        var permutationsRules = RuleOverlapAlgo.GetPermutations<PromotionRule>(promotionRules, promotionRules.Count());
+        List<int> maxSavings;
+        RuleOverlapAlgo.SavingsForAllPermutationsOfRules(counts, permutationsRules, out maxSavings);
+        IEnumerable<PromotionRule> rulePermMaxSaving = RuleOverlapAlgo.RulePermutationMaxSavings(permutationsRules, maxSavings);
+
+        // Act
+        var totalPrice = counts.TotalPriceUsingPromotionRules(promotionRules);
+        var totalPriceWithMaxSavingsPermutation = counts.TotalPriceUsingPromotionRules(rulePermMaxSaving);
+
+        // Assert
+        bool result = totalPriceWithMaxSavingsPermutation < totalPrice;
+        Assert.IsTrue(result, String.Format("total price with MaxSavings '{0}' < '{1}': true, but actual price '{1}': {2}", totalPriceWithMaxSavingsPermutation, totalPrice, result));
     }
 }


### PR DESCRIPTION
Description: Total price computation no longer assumes independent non-overlapping promotion rules. Algo for MaxSavings of total price selects a lowest total price which derives from a permutation of applied overlapping rules leading to max savings and therefore also lowest total price assuming each rule is applied in an exhaustive manner of sku consumption. There may exist edge cases where this exhaustive manner does not lead to lowest total price. Included are unit tests for MaxSavings algo and they all pass.